### PR TITLE
修复一些细节

### DIFF
--- a/app/Http/Controllers/ClosetController.php
+++ b/app/Http/Controllers/ClosetController.php
@@ -119,7 +119,7 @@ class ClosetController extends Controller
             $t->save();
 
             if (option('return_score'))
-                app('user.current')->setScore(option('score_per_closet_item'), 'minus');
+                app('user.current')->setScore(option('score_per_closet_item'), 'plus');
 
             return json(trans('user.closet.remove.success'), 0);
         } else {

--- a/app/Http/Controllers/SkinlibController.php
+++ b/app/Http/Controllers/SkinlibController.php
@@ -30,7 +30,7 @@ class SkinlibController extends Controller
     {
         $filter  = $request->input('filter', 'skin');
         $sort    = $request->input('sort', 'time');
-        $uid     = $request->input('uid', 0);
+        $uid     = $request->input('uid', session('uid'));
         $page    = $request->input('page', 1);
         $page    = $page <= 0 ? 1 : $page;
 
@@ -51,8 +51,9 @@ class SkinlibController extends Controller
 
         if (!is_null($this->user)) {
             // show private textures when show uploaded textures of current user
-            if ($uid != $this->user->uid && !$this->user->isAdmin())
-                $textures = $textures->where('public', '1');
+            if (!$this->user->isAdmin())
+                $textures = $textures->where('public', '1')
+                                     ->orWhere('uploader', $this->user->uid);
         } else {
             $textures = $textures->where('public', '1');
         }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -73,6 +73,7 @@ class UserController extends Controller
                 'errno'          => 0,
                 'msg'            => trans('user.sign-in-success', ['score' => $acuiredScore]),
                 'score'          => $this->user->getScore(),
+                'storage'        => $this->calculatePercentageUsed($this->user->getStorageUsed(), option('score_per_storage')),
                 'remaining_time' => round($this->user->getSignInRemainingTime() / 3600)
             ]);
         } else {

--- a/app/Models/Closet.php
+++ b/app/Models/Closet.php
@@ -238,4 +238,18 @@ class Closet
         $this->save();
     }
 
+    /**
+     * Get all closets.
+     *
+     * @return array
+     */
+    public static function all()
+    {
+        $result = [];
+        foreach (DB::table('closets')->lists('uid') as $uid) {
+            $result[] = new Closet($uid);
+        }
+        return $result;
+    }
+
 }

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "A web application brings your custom skins back in offline Minecraft servers.",
     "license": "GPL-3.0",
     "require": {
-        "php": "^5.5.9",
+        "php": ">=5.5.9",
         "filp/whoops": "^2.1",
         "predis/predis": "~1.0",
         "gregwar/captcha": "^1.1",

--- a/config/options.php
+++ b/config/options.php
@@ -2,8 +2,8 @@
 /**
  * @Author: printempw
  * @Date:   2016-07-29 11:53:11
- * @Last Modified by:   printempw
- * @Last Modified time: 2017-01-20 19:24:21
+ * @Last Modified by:   g-plane
+ * @Last Modified time: 2017-04-21 13:01:49
  */
 
 return [
@@ -32,7 +32,7 @@ return [
     'version'                   => '',
     'check_update'              => 'true',
     'update_source'             => 'https://work.prinzeugen.net/update.json',
-    'copyright_text'            => '<strong>Copyright &copy; 2016 <a href="{site_url}">{site_name}</a>.</strong> All rights reserved.',
+    'copyright_text'            => '<strong>Copyright &copy; '.getdate()['year'].' <a href="{site_url}">{site_name}</a>.</strong> All rights reserved.',
     'auto_del_invalid_texture'  => 'false',
     'return_200_when_notfound'  => 'false',
     'cache_expire_time'         => '31536000',

--- a/resources/assets/src/scripts/admin.js
+++ b/resources/assets/src/scripts/admin.js
@@ -187,6 +187,7 @@ function deleteUserAccount(uid) {
 $('body').on('keypress', '.score', function(event){
     if (event.which == 13) {
         changeUserScore($(this).parent().parent().attr('id'), $(this).val());
+        $(this).blur();
     }
 });
 

--- a/resources/assets/src/scripts/skinlib.js
+++ b/resources/assets/src/scripts/skinlib.js
@@ -156,7 +156,11 @@ function handleFiles(files, type) {
                 img.onload = () => {
 
                     (type == "skin") ? MSP.changeSkin(img.src) : MSP.changeCape(img.src);
-                    $('#name').val($('#name').val() == "" ? file.name.split('.png')[0] : $('#name').val());
+                    let domTextureName = $('#name');
+                    if (domTextureName.val() === '' || domTextureName.val() === domTextureName.attr('data-last-file-name')) {
+                        domTextureName.attr('data-last-file-name', file.name);
+                        domTextureName.val(file.name);
+                    }
                 };
                 img.onerror = () => toastr.warning(trans('skinlib.fileExtError'));
 

--- a/resources/assets/src/scripts/user.js
+++ b/resources/assets/src/scripts/user.js
@@ -20,11 +20,11 @@ $('body').on('click', '#preview-switch', () => {
 
 var selected = [];
 
-$('body').on('click', '.item', function () {
-    $('.item-selected').removeClass('item-selected');
-    $(this).addClass('item-selected');
+$('body').on('click', '.item-body', function () {
+    $('.item-selected').parent().removeClass('item-selected');
+    $(this).parent().addClass('item-selected');
 
-    let tid = $(this).attr('tid');
+    let tid = $(this).parent().attr('tid');
 
     $.ajax({
         type: "POST",

--- a/resources/assets/src/scripts/user.js
+++ b/resources/assets/src/scripts/user.js
@@ -554,6 +554,14 @@ function signIn() {
                 var dom = '<i class="fa fa-calendar-check-o"></i> &nbsp;' + trans('user.signInRemainingTime', { time: String(json.remaining_time) });
                 $('#sign-in-button').attr('disabled', 'disabled').html(dom);
 
+                if (json.storage.used > 1024) {
+                    $('#user-storage').html(`<b>${Math.round(json.storage.used)}</b>/ ${Math.round(json.storage.total)} MB`);
+                } else {
+                    $('#user-storage').html(`<b>${Math.round(json.storage.used)}</b>/ ${Math.round(json.storage.total)} KB`);
+                }
+
+                $('#user-storage-bar').css('width', `${json.storage.percentage}%`)
+
                 swal({
                     type: 'success',
                     html: json.msg

--- a/resources/lang/en/skinlib.yml
+++ b/resources/lang/en/skinlib.yml
@@ -14,6 +14,7 @@ filter:
   steve-model: (Steve Model)
   alex-model: (Alex Model)
   uploader: User (:name) Uploaded
+  clean-filter: Clean Filter
 
 sort:
   newest-uploaded: Newestly Uploaded

--- a/resources/lang/en/user.yml
+++ b/resources/lang/en/user.yml
@@ -25,10 +25,10 @@ score-intro:
     player: :score scores = 1 player
 
 closet:
-  upload: Uplaod Texture
+  upload: Upload Texture
   search: Search Texture
   switch-category: Switch Category
-  view: View in skin librariy
+  view: View in skin library
   more: More
   set-avatar: Set as avatar
   empty-msg: |

--- a/resources/lang/zh_CN/skinlib.yml
+++ b/resources/lang/zh_CN/skinlib.yml
@@ -14,6 +14,7 @@ filter:
   steve-model: （Steve 模型）
   alex-model: （Alex 模型）
   uploader: 用户（:name）上传
+  clean-filter: 清除筛选
 
 sort:
   newest-uploaded: 最新上传

--- a/resources/views/skinlib/master.tpl
+++ b/resources/views/skinlib/master.tpl
@@ -48,6 +48,8 @@
                                     <li class="divider"></li>
                                     <li><a href="?filter=user&uid={{ $user->uid }}&sort={{ $sort }}">{{ trans('skinlib.general.my-upload') }}</a></li>
                                     @endif
+                                    <li class="divider"></li>
+                                    <li><a href="/skinlib">{{ trans('skinlib.filter.clean-filter') }}</a></li>
                                 </ul>
                             </li>
 

--- a/resources/views/user/index.tpl
+++ b/resources/views/user/index.tpl
@@ -44,18 +44,16 @@
                                         $total = $statistics['storage']['total'];
                                     ?>
 
-                                    @if ($used > 1024)
-                                    <span class="progress-number">
-                                        <b>{{ round($used / 1024, 1) }}</b>/ {{ is_string($total) ? $total : round($total / 1024, 1) }} MB
+                                    <span class="progress-number" id="user-storage">
+                                        @if ($used > 1024)
+                                            <b>{{ round($used / 1024, 1) }}</b>/ {{ is_string($total) ? $total : round($total / 1024, 1) }} MB
+                                        @else
+                                            <b>{{ $used }}</b>/ {{ $total }} KB
+                                        @endif
                                     </span>
-                                    @else
-                                    <span class="progress-number">
-                                        <b>{{ $used }}</b>/ {{ $total }} KB
-                                    </span>
-                                    @endif
 
                                     <div class="progress sm">
-                                        <div class="progress-bar progress-bar-yellow" style="width: {{ $statistics['storage']['percentage'] }}%"></div>
+                                        <div class="progress-bar progress-bar-yellow" id="user-storage-bar" style="width: {{ $statistics['storage']['percentage'] }}%"></div>
                                     </div>
                                 </div><!-- /.progress-group -->
                             </div><!-- /.col -->

--- a/resources/views/vendor/admin-operations/players/previews.tpl
+++ b/resources/views/vendor/admin-operations/players/previews.tpl
@@ -1,7 +1,7 @@
 @if ($tid_steve == '0')
 <img id="{{ $pid }}-steve" width="64" />
 @else
-<a href="{{ url('skinlib/show?tid='.$tid_steve) }}">
+<a href="{{ url('skinlib/show/'.$tid_steve) }}">
     <img id="{{ $pid }}-steve" width="64" src="{{ url('preview/64/'.$tid_steve) }}.png" />
 </a>
 @endif
@@ -9,7 +9,7 @@
 @if ($tid_alex == '0')
 <img id="{{ $pid }}-alex" width="64" />
 @else
-<a href="{{ url('skinlib/show?tid='.$tid_alex) }}">
+<a href="{{ url('skinlib/show/'.$tid_alex) }}">
     <img id="{{ $pid }}-alex" width="64" src="{{ url('preview/64/'.$tid_alex) }}.png" />
 </a>
 @endif
@@ -17,7 +17,7 @@
 @if ($tid_cape == '0')
 <img id="{{ $pid }}-cape" width="64" />
 @else
-<a href="{{ url('skinlib/show?tid='.$tid_cape) }}">
+<a href="{{ url('skinlib/show/'.$tid_cape) }}">
     <img id="{{ $pid }}-cape" width="64" src="{{ url('preview/64/'.$tid_cape) }}.png" />
 </a>
 @endif


### PR DESCRIPTION
已经修复的：
- [修复] `composer.json` 中对 PHP 版本的检测
- [修复] 管理面板中“角色管理”页面指向“材质预览”页面的链接
- [改进] 在“上传材质”页面，若重新选择文件，可以更新“材质名称”输入框的值
- [改进] 签到时自动更新储存空间的显示
- [改进] “管理面板”中更改用户积分后输入框自动失去焦点
- [改进] 点击“我的衣柜”页面的“齿轮”图标不再同时更新材质预览
- [修复] 语言文件拼写错误
- [改进] 页面底部版权信息的年份 #58 
- [修复] 皮肤库中不显示上传者自己的隐私材质问题
- [增加] 皮肤库中清除筛选的选项
- [修复] 对原来公开的材质设为“私有”的问题
- [修复] 多处对积分的计算

对于 #50 中没有修复的：
- “用户中心”中的“角色管理”页面没有使用 `@include('vendor.texture-preview')`
> 这个只是代码层面的问题，不修复不会对用户体验产生影响
- “我的衣柜”中分页问题