### PR TITLE
一些疏漏

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -334,7 +334,7 @@ class AdminController extends Controller
                 'tid'   => 'required|integer'
             ]);
 
-            if (!Texture::find($request->tid))
+            if (!Texture::find($request->tid) && $request->tid != 0)
                 return json(trans('admin.players.textures.non-existent', ['tid' => $request->tid]), 1);
 
             $player->setTexture(['tid_'.$request->model => $request->tid]);


### PR DESCRIPTION
真是不好意思。
之前在“更改角色材质”的模态对话框中加了一句话，说“把 TID 设成 0 就可以清除该角色的材质”，然后忘了在后端加上相应的实现，现在补上。